### PR TITLE
Ignore `default` stream when handling reactive tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A suite of tests for checking rtc-tools compatibility with any valid signaller",
   "main": "index.js",
   "scripts": {
-    "test": "browserify test-latest.js | broth start-$BROWSER | tap-spec",
+    "test": "browserify test-latest.js | broth start | tap-spec",
     "gendocs": "gendocs > README.md"
   },
   "repository": {
@@ -37,6 +37,6 @@
     "rtc-tools": "^4.2.3",
     "tap-spec": "^4.0.2",
     "tape": "^4.0.1",
-    "travis-multirunner": "^2.0.7"
+    "travis-multirunner": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rtc-signaller": "^6.2.1",
     "rtc-switchboard": "^3.0.0",
     "rtc-switchboard-messenger": "^1.0.0",
-    "rtc-tools": "^4.2.3",
+    "rtc-tools": "^5.0.1",
     "tap-spec": "^4.0.2",
     "tape": "^4.0.1",
     "travis-multirunner": "^3.0.0"

--- a/test/subtest-reactive-randomdelay-streams.js
+++ b/test/subtest-reactive-randomdelay-streams.js
@@ -105,6 +105,18 @@ module.exports = function(rtc, createSignaller, signallerOpts) {
       }
 
       function handleStream(evt) {
+        // NOTE!
+        // As the default offer constraints generated in rtc-taskqueue/index#generateConstraints
+        // includes {offerToReceiveAudio: true, offerToReceiveVideo: true}, Chrome will, in the
+        // absence of a appropriate stream to return will create a default stream to fit these requirements
+        // However, once a properly named stream exists (ie. passed with an msid:semantic id in the SDP),
+        // it will go ahead and remove the default stream
+        // The code for this can be found in the Chrome PeerConnection#SetRemoteDescription implementation, found at
+        // https://chromium.googlesource.com/external/webrtc/+/master/talk/app/webrtc/peerconnection.cc#1026
+        //
+        // So, TLDR, we ignore default streams for the purposes of this test
+        if (evt.stream.id === 'default') return console.warn('Chrome default stream detected, ignoring');
+
         var streamIdx = pendingIds.indexOf(evt && evt.stream && evt.stream.id);
         t.ok(streamIdx >= 0, 'stream found: ' + evt.stream.id);
         pendingCount -= 1;

--- a/test/subtest-reactive-randomdelay-streams.js
+++ b/test/subtest-reactive-randomdelay-streams.js
@@ -115,7 +115,7 @@ module.exports = function(rtc, createSignaller, signallerOpts) {
         // https://chromium.googlesource.com/external/webrtc/+/master/talk/app/webrtc/peerconnection.cc#1026
         //
         // So, TLDR, we ignore default streams for the purposes of this test
-        if (evt.stream.id === 'default') return console.warn('Chrome default stream detected, ignoring');
+        if (evt.stream.id === 'default') return console.log('Chrome default stream detected, ignoring');
 
         var streamIdx = pendingIds.indexOf(evt && evt.stream && evt.stream.id);
         t.ok(streamIdx >= 0, 'stream found: ' + evt.stream.id);

--- a/test/subtest-reactive-randomdelay-streams.js
+++ b/test/subtest-reactive-randomdelay-streams.js
@@ -76,7 +76,7 @@ module.exports = function(rtc, createSignaller, signallerOpts) {
       t.ok(monitors[1], 'ok');
     });
 
-    test(name + ': create streams', function(t) {
+    test(name + ': create streams', {timeout: 30000}, function(t) {
       var masterIdx = signallers[0].isMaster(remoteIds[1]) ? 0 : 1;
       var ids = times(streamCount).map(function(idx) {
         return 'newstream_' + idx;


### PR DESCRIPTION
Chrome's default media stream was causing the reactive tests to fail, so ignore the default stream when it occurs.

Also added a note explaining why this happens for future reference, and if the implementation in `rtc-taskqueue#generateConstraints()` should change.